### PR TITLE
Fix techage -- fixes from PR to upstream

### DIFF
--- a/mapgen_mineral_waters_under.lua
+++ b/mapgen_mineral_waters_under.lua
@@ -59,6 +59,7 @@ minetest.register_on_mods_loaded(function()
         if
             table.indexof(wherein, mapgen_stone_itemstring) > -1
             and not biomes
+            and def.clust_scarcity ~= 1 -- ignore ores that replace everything
         then
             def.wherein = { 'everness:mineral_cave_stone' }
             def.biomes = { 'everness:mineral_waters_under' }

--- a/mapgen_mineral_waters_under.lua
+++ b/mapgen_mineral_waters_under.lua
@@ -61,6 +61,7 @@ minetest.register_on_mods_loaded(function()
             and not biomes
             and def.clust_scarcity ~= 1 -- ignore ores that replace everything
         then
+            def = table.copy(def)
             def.wherein = { 'everness:mineral_cave_stone' }
             def.biomes = { 'everness:mineral_waters_under' }
             def.y_max = y_max


### PR DESCRIPTION
I merged in the fixes from the PR I made to upstream everness:

* [fix techage's gravel sieve which was not working due to ore definitions getting overwritten](https://bitbucket.org/minetest_gamers/everness/pull-requests/30)
* I'm also including [a fix for nssb](https://bitbucket.org/minetest_gamers/everness/pull-requests/29), but it doesn't actually affect asuna's version since you apparently disable generating `everness:mineral_cave_stone` anyway.